### PR TITLE
don't merge until BTE asks: update to replace semantic: ChemicalSubstance 

### DIFF
--- a/ehr_risk_kp.yaml
+++ b/ehr_risk_kp.yaml
@@ -14,6 +14,7 @@ info:
     team:
     - Multiomics Provider
     - Service Provider
+    biolink-version: "2.1.0"
 servers:
 - description: Encrypted Production server
   url: https://biothings.ncats.io/clinical_risk_kp

--- a/ehr_risk_kp.yaml
+++ b/ehr_risk_kp.yaml
@@ -705,10 +705,10 @@ components:
     ChemicalSubstance0-ChemicalSubstance0-associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -723,10 +723,10 @@ components:
     ChemicalSubstance0-ChemicalSubstance0-negatively_associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -741,10 +741,10 @@ components:
     ChemicalSubstance0-ChemicalSubstance0-negatively_correlated_with:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -759,10 +759,10 @@ components:
     ChemicalSubstance0-ChemicalSubstance0-related_to:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -777,10 +777,10 @@ components:
     ChemicalSubstance0-ChemicalSubstance5-associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -795,10 +795,10 @@ components:
     ChemicalSubstance0-ChemicalSubstance5-negatively_associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -813,10 +813,10 @@ components:
     ChemicalSubstance0-ChemicalSubstance5-negatively_correlated_with:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -831,10 +831,10 @@ components:
     ChemicalSubstance0-ChemicalSubstance5-related_to:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -849,7 +849,7 @@ components:
     ChemicalSubstance0-Disease2-associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: MONDO
         semantic: Disease
@@ -867,7 +867,7 @@ components:
     ChemicalSubstance0-Disease2-negatively_associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: MONDO
         semantic: Disease
@@ -885,7 +885,7 @@ components:
     ChemicalSubstance0-Disease2-negatively_correlated_with:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: MONDO
         semantic: Disease
@@ -903,7 +903,7 @@ components:
     ChemicalSubstance0-Disease2-related_to:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: MONDO
         semantic: Disease
@@ -921,7 +921,7 @@ components:
     ChemicalSubstance0-Disease3-associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Disease
@@ -939,7 +939,7 @@ components:
     ChemicalSubstance0-Disease3-negatively_associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Disease
@@ -957,7 +957,7 @@ components:
     ChemicalSubstance0-Disease3-negatively_correlated_with:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Disease
@@ -975,7 +975,7 @@ components:
     ChemicalSubstance0-Disease3-related_to:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Disease
@@ -993,7 +993,7 @@ components:
     ChemicalSubstance0-Disease4-associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: Disease
@@ -1011,7 +1011,7 @@ components:
     ChemicalSubstance0-Disease4-negatively_associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: Disease
@@ -1029,7 +1029,7 @@ components:
     ChemicalSubstance0-Disease4-negatively_correlated_with:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: Disease
@@ -1047,7 +1047,7 @@ components:
     ChemicalSubstance0-Disease4-related_to:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: Disease
@@ -1065,7 +1065,7 @@ components:
     ChemicalSubstance0-PhenotypicFeature1-associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: HP
         semantic: PhenotypicFeature
@@ -1083,7 +1083,7 @@ components:
     ChemicalSubstance0-PhenotypicFeature1-negatively_associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: HP
         semantic: PhenotypicFeature
@@ -1101,7 +1101,7 @@ components:
     ChemicalSubstance0-PhenotypicFeature1-negatively_correlated_with:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: HP
         semantic: PhenotypicFeature
@@ -1119,7 +1119,7 @@ components:
     ChemicalSubstance0-PhenotypicFeature1-related_to:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: HP
         semantic: PhenotypicFeature
@@ -1137,7 +1137,7 @@ components:
     ChemicalSubstance0-PhenotypicFeature3-associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: PhenotypicFeature
@@ -1155,7 +1155,7 @@ components:
     ChemicalSubstance0-PhenotypicFeature3-negatively_associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: PhenotypicFeature
@@ -1173,7 +1173,7 @@ components:
     ChemicalSubstance0-PhenotypicFeature3-negatively_correlated_with:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: PhenotypicFeature
@@ -1191,7 +1191,7 @@ components:
     ChemicalSubstance0-PhenotypicFeature3-related_to:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: PhenotypicFeature
@@ -1209,7 +1209,7 @@ components:
     ChemicalSubstance0-PhenotypicFeature4-associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: PhenotypicFeature
@@ -1227,7 +1227,7 @@ components:
     ChemicalSubstance0-PhenotypicFeature4-negatively_associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: PhenotypicFeature
@@ -1245,7 +1245,7 @@ components:
     ChemicalSubstance0-PhenotypicFeature4-negatively_correlated_with:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: PhenotypicFeature
@@ -1263,7 +1263,7 @@ components:
     ChemicalSubstance0-PhenotypicFeature4-related_to:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: PhenotypicFeature
@@ -1281,7 +1281,7 @@ components:
     ChemicalSubstance0-Procedure3-associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Procedure
@@ -1299,7 +1299,7 @@ components:
     ChemicalSubstance0-Procedure3-negatively_associated_with_risk_for:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Procedure
@@ -1317,7 +1317,7 @@ components:
     ChemicalSubstance0-Procedure3-negatively_correlated_with:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Procedure
@@ -1335,7 +1335,7 @@ components:
     ChemicalSubstance0-Procedure3-related_to:
     - inputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Procedure
@@ -1353,10 +1353,10 @@ components:
     ChemicalSubstance5-ChemicalSubstance0-associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:UNII\:{inputs[0]} AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -1371,10 +1371,10 @@ components:
     ChemicalSubstance5-ChemicalSubstance0-negatively_associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:UNII\:{inputs[0]} AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -1389,10 +1389,10 @@ components:
     ChemicalSubstance5-ChemicalSubstance0-negatively_correlated_with:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:UNII\:{inputs[0]} AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -1407,10 +1407,10 @@ components:
     ChemicalSubstance5-ChemicalSubstance0-related_to:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:UNII\:{inputs[0]} AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -1425,10 +1425,10 @@ components:
     ChemicalSubstance5-ChemicalSubstance5-associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:UNII\:{inputs[0]} AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -1443,10 +1443,10 @@ components:
     ChemicalSubstance5-ChemicalSubstance5-negatively_associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:UNII\:{inputs[0]} AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -1461,10 +1461,10 @@ components:
     ChemicalSubstance5-ChemicalSubstance5-negatively_correlated_with:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:UNII\:{inputs[0]} AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -1479,10 +1479,10 @@ components:
     ChemicalSubstance5-ChemicalSubstance5-related_to:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:UNII\:{inputs[0]} AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -1497,7 +1497,7 @@ components:
     ChemicalSubstance5-Disease2-associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: MONDO
         semantic: Disease
@@ -1515,7 +1515,7 @@ components:
     ChemicalSubstance5-Disease2-negatively_associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: MONDO
         semantic: Disease
@@ -1533,7 +1533,7 @@ components:
     ChemicalSubstance5-Disease2-negatively_correlated_with:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: MONDO
         semantic: Disease
@@ -1551,7 +1551,7 @@ components:
     ChemicalSubstance5-Disease2-related_to:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: MONDO
         semantic: Disease
@@ -1569,7 +1569,7 @@ components:
     ChemicalSubstance5-Disease3-associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Disease
@@ -1587,7 +1587,7 @@ components:
     ChemicalSubstance5-Disease3-negatively_associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Disease
@@ -1605,7 +1605,7 @@ components:
     ChemicalSubstance5-Disease3-negatively_correlated_with:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Disease
@@ -1623,7 +1623,7 @@ components:
     ChemicalSubstance5-Disease3-related_to:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Disease
@@ -1641,7 +1641,7 @@ components:
     ChemicalSubstance5-Disease4-associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: Disease
@@ -1659,7 +1659,7 @@ components:
     ChemicalSubstance5-Disease4-negatively_associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: Disease
@@ -1677,7 +1677,7 @@ components:
     ChemicalSubstance5-Disease4-negatively_correlated_with:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: Disease
@@ -1695,7 +1695,7 @@ components:
     ChemicalSubstance5-Disease4-related_to:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: Disease
@@ -1713,7 +1713,7 @@ components:
     ChemicalSubstance5-PhenotypicFeature1-associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: HP
         semantic: PhenotypicFeature
@@ -1731,7 +1731,7 @@ components:
     ChemicalSubstance5-PhenotypicFeature1-negatively_associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: HP
         semantic: PhenotypicFeature
@@ -1749,7 +1749,7 @@ components:
     ChemicalSubstance5-PhenotypicFeature1-negatively_correlated_with:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: HP
         semantic: PhenotypicFeature
@@ -1767,7 +1767,7 @@ components:
     ChemicalSubstance5-PhenotypicFeature1-related_to:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: HP
         semantic: PhenotypicFeature
@@ -1785,7 +1785,7 @@ components:
     ChemicalSubstance5-PhenotypicFeature3-associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: PhenotypicFeature
@@ -1803,7 +1803,7 @@ components:
     ChemicalSubstance5-PhenotypicFeature3-negatively_associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: PhenotypicFeature
@@ -1821,7 +1821,7 @@ components:
     ChemicalSubstance5-PhenotypicFeature3-negatively_correlated_with:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: PhenotypicFeature
@@ -1839,7 +1839,7 @@ components:
     ChemicalSubstance5-PhenotypicFeature3-related_to:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: PhenotypicFeature
@@ -1857,7 +1857,7 @@ components:
     ChemicalSubstance5-PhenotypicFeature4-associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: PhenotypicFeature
@@ -1875,7 +1875,7 @@ components:
     ChemicalSubstance5-PhenotypicFeature4-negatively_associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: PhenotypicFeature
@@ -1893,7 +1893,7 @@ components:
     ChemicalSubstance5-PhenotypicFeature4-negatively_correlated_with:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: PhenotypicFeature
@@ -1911,7 +1911,7 @@ components:
     ChemicalSubstance5-PhenotypicFeature4-related_to:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: SNOMEDCT
         semantic: PhenotypicFeature
@@ -1929,7 +1929,7 @@ components:
     ChemicalSubstance5-Procedure3-associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Procedure
@@ -1947,7 +1947,7 @@ components:
     ChemicalSubstance5-Procedure3-negatively_associated_with_risk_for:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Procedure
@@ -1965,7 +1965,7 @@ components:
     ChemicalSubstance5-Procedure3-negatively_correlated_with:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Procedure
@@ -1983,7 +1983,7 @@ components:
     ChemicalSubstance5-Procedure3-related_to:
     - inputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       outputs:
       - id: NCIT
         semantic: Procedure
@@ -2004,7 +2004,7 @@ components:
         semantic: Disease
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -2022,7 +2022,7 @@ components:
         semantic: Disease
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -2040,7 +2040,7 @@ components:
         semantic: Disease
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -2058,7 +2058,7 @@ components:
         semantic: Disease
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -2076,7 +2076,7 @@ components:
         semantic: Disease
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -2094,7 +2094,7 @@ components:
         semantic: Disease
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -2112,7 +2112,7 @@ components:
         semantic: Disease
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -2130,7 +2130,7 @@ components:
         semantic: Disease
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -2652,7 +2652,7 @@ components:
         semantic: Disease
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -2670,7 +2670,7 @@ components:
         semantic: Disease
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -2688,7 +2688,7 @@ components:
         semantic: Disease
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -2706,7 +2706,7 @@ components:
         semantic: Disease
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -2724,7 +2724,7 @@ components:
         semantic: Disease
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -2742,7 +2742,7 @@ components:
         semantic: Disease
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -2760,7 +2760,7 @@ components:
         semantic: Disease
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -2778,7 +2778,7 @@ components:
         semantic: Disease
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -3300,7 +3300,7 @@ components:
         semantic: Disease
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -3318,7 +3318,7 @@ components:
         semantic: Disease
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -3336,7 +3336,7 @@ components:
         semantic: Disease
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -3354,7 +3354,7 @@ components:
         semantic: Disease
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -3372,7 +3372,7 @@ components:
         semantic: Disease
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -3390,7 +3390,7 @@ components:
         semantic: Disease
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -3408,7 +3408,7 @@ components:
         semantic: Disease
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -3426,7 +3426,7 @@ components:
         semantic: Disease
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -3948,7 +3948,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -3966,7 +3966,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -3984,7 +3984,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -4002,7 +4002,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -4020,7 +4020,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -4038,7 +4038,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -4056,7 +4056,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -4074,7 +4074,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -4596,7 +4596,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -4614,7 +4614,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -4632,7 +4632,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -4650,7 +4650,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -4668,7 +4668,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -4686,7 +4686,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -4704,7 +4704,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -4722,7 +4722,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -5244,7 +5244,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -5262,7 +5262,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -5280,7 +5280,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -5298,7 +5298,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -5316,7 +5316,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -5334,7 +5334,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -5352,7 +5352,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -5370,7 +5370,7 @@ components:
         semantic: PhenotypicFeature
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -5892,7 +5892,7 @@ components:
         semantic: Procedure
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -5910,7 +5910,7 @@ components:
         semantic: Procedure
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -5928,7 +5928,7 @@ components:
         semantic: Procedure
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -5946,7 +5946,7 @@ components:
         semantic: Procedure
       outputs:
       - id: CHEBI
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to
@@ -5964,7 +5964,7 @@ components:
         semantic: Procedure
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:associated_with_risk_for
@@ -5982,7 +5982,7 @@ components:
         semantic: Procedure
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_associated_with_risk_for
@@ -6000,7 +6000,7 @@ components:
         semantic: Procedure
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:negatively_correlated_with
@@ -6018,7 +6018,7 @@ components:
         semantic: Procedure
       outputs:
       - id: UNII
-        semantic: ChemicalSubstance
+        semantic: SmallMolecule
       parameters:
         fields: subject,predicate
         q: object.id:"{inputs[0]}" AND subject.type:ChemicalSubstance AND predicate.type:related_to


### PR DESCRIPTION
replace "semantic: ChemicalSubstance" to "semantic: SmallMolecule"

DON'T MERGE until BTE team asks for this. BTE needs to update tools to migrate everything over to SmallMolecule. 

quick fix for biolink v2.0 compliance
more detailed fix for biolink v2.0 may involve mapping some or all things to DRUG instead. 

related to https://github.com/biothings/BioThings_Explorer_TRAPI/issues/207