### PR TITLE
update for provenance standards

### DIFF
--- a/ehr_risk_kp.yaml
+++ b/ehr_risk_kp.yaml
@@ -10,6 +10,7 @@ info:
   title: Clinical Risk KP API
   version: '1.1'
   x-translator:
+    infores-curie: "infores:biothings-multiomics-clinical-risk"
     component: KP
     team:
     - Multiomics Provider
@@ -520,7 +521,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance0'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance0-Disease2-positively_correlated_with:
     - inputs:
@@ -538,7 +539,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/ChemicalSubstance0'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance0-Disease3-negatively_correlated_with:
     - inputs:
@@ -556,7 +557,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance0-Disease3-positively_correlated_with:
     - inputs:
@@ -574,7 +575,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance0-Disease4-negatively_correlated_with:
     - inputs:
@@ -592,7 +593,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance0-Disease4-positively_correlated_with:
     - inputs:
@@ -610,7 +611,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance0-PhenotypicFeature1-negatively_correlated_with:
     - inputs:
@@ -628,7 +629,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance0-PhenotypicFeature1-positively_correlated_with:
     - inputs:
@@ -646,7 +647,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance0-PhenotypicFeature3-negatively_correlated_with:
     - inputs:
@@ -664,7 +665,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance0-PhenotypicFeature3-positively_correlated_with:
     - inputs:
@@ -682,7 +683,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance0-PhenotypicFeature4-negatively_correlated_with:
     - inputs:
@@ -700,7 +701,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance0-PhenotypicFeature4-positively_correlated_with:
     - inputs:
@@ -718,7 +719,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance0-Procedure3-negatively_correlated_with:
     - inputs:
@@ -736,7 +737,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance0-Procedure3-positively_correlated_with:
     - inputs:
@@ -754,7 +755,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance5-Disease2-negatively_correlated_with:
     - inputs:
@@ -772,7 +773,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance5-Disease2-positively_correlated_with:
     - inputs:
@@ -790,7 +791,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance5-Disease3-negatively_correlated_with:
     - inputs:
@@ -808,7 +809,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance5-Disease3-positively_correlated_with:
     - inputs:
@@ -826,7 +827,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance5-Disease4-negatively_correlated_with:
     - inputs:
@@ -844,7 +845,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance5-Disease4-positively_correlated_with:
     - inputs:
@@ -862,7 +863,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance5-PhenotypicFeature1-negatively_correlated_with:
     - inputs:
@@ -880,7 +881,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance5-PhenotypicFeature1-positively_correlated_with:
     - inputs:
@@ -898,7 +899,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance5-PhenotypicFeature3-negatively_correlated_with:
     - inputs:
@@ -916,7 +917,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance5-PhenotypicFeature3-positively_correlated_with:
     - inputs:
@@ -934,7 +935,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance5-PhenotypicFeature4-negatively_correlated_with:
     - inputs:
@@ -952,7 +953,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance5-PhenotypicFeature4-positively_correlated_with:
     - inputs:
@@ -970,7 +971,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance5-Procedure3-negatively_correlated_with:
     - inputs:
@@ -988,7 +989,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     ChemicalSubstance5-Procedure3-positively_correlated_with:
     - inputs:
@@ -1006,7 +1007,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease2-Disease2-negatively_correlated_with:
     - inputs:
@@ -1024,7 +1025,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease2-Disease2-positively_correlated_with:
     - inputs:
@@ -1042,7 +1043,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease2-Disease3-negatively_correlated_with:
     - inputs:
@@ -1060,7 +1061,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease2-Disease3-positively_correlated_with:
     - inputs:
@@ -1078,7 +1079,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease2-Disease4-negatively_correlated_with:
     - inputs:
@@ -1096,7 +1097,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease2-Disease4-positively_correlated_with:
     - inputs:
@@ -1114,7 +1115,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease2-PhenotypicFeature1-negatively_correlated_with:
     - inputs:
@@ -1132,7 +1133,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease2-PhenotypicFeature1-positively_correlated_with:
     - inputs:
@@ -1150,7 +1151,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease2-PhenotypicFeature3-negatively_correlated_with:
     - inputs:
@@ -1168,7 +1169,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease2-PhenotypicFeature3-positively_correlated_with:
     - inputs:
@@ -1186,7 +1187,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease2-PhenotypicFeature4-negatively_correlated_with:
     - inputs:
@@ -1204,7 +1205,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease2-PhenotypicFeature4-positively_correlated_with:
     - inputs:
@@ -1222,7 +1223,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease2-Procedure3-negatively_correlated_with:
     - inputs:
@@ -1240,7 +1241,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease2-Procedure3-positively_correlated_with:
     - inputs:
@@ -1258,7 +1259,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease3-Disease2-negatively_correlated_with:
     - inputs:
@@ -1276,7 +1277,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease3-Disease2-positively_correlated_with:
     - inputs:
@@ -1294,7 +1295,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease3-Disease3-negatively_correlated_with:
     - inputs:
@@ -1312,7 +1313,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease3-Disease3-positively_correlated_with:
     - inputs:
@@ -1330,7 +1331,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease3-Disease4-negatively_correlated_with:
     - inputs:
@@ -1348,7 +1349,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease3-Disease4-positively_correlated_with:
     - inputs:
@@ -1366,7 +1367,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease3-PhenotypicFeature1-negatively_correlated_with:
     - inputs:
@@ -1384,7 +1385,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease3-PhenotypicFeature1-positively_correlated_with:
     - inputs:
@@ -1402,7 +1403,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease3-PhenotypicFeature3-negatively_correlated_with:
     - inputs:
@@ -1420,7 +1421,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease3-PhenotypicFeature3-positively_correlated_with:
     - inputs:
@@ -1438,7 +1439,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease3-PhenotypicFeature4-negatively_correlated_with:
     - inputs:
@@ -1456,7 +1457,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease3-PhenotypicFeature4-positively_correlated_with:
     - inputs:
@@ -1474,7 +1475,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease3-Procedure3-negatively_correlated_with:
     - inputs:
@@ -1492,7 +1493,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease3-Procedure3-positively_correlated_with:
     - inputs:
@@ -1510,7 +1511,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease4-Disease2-negatively_correlated_with:
     - inputs:
@@ -1528,7 +1529,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease4-Disease2-positively_correlated_with:
     - inputs:
@@ -1546,7 +1547,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease4-Disease3-negatively_correlated_with:
     - inputs:
@@ -1564,7 +1565,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease4-Disease3-positively_correlated_with:
     - inputs:
@@ -1582,7 +1583,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease4-Disease4-negatively_correlated_with:
     - inputs:
@@ -1600,7 +1601,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease4-Disease4-positively_correlated_with:
     - inputs:
@@ -1618,7 +1619,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease4-PhenotypicFeature1-negatively_correlated_with:
     - inputs:
@@ -1636,7 +1637,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease4-PhenotypicFeature1-positively_correlated_with:
     - inputs:
@@ -1654,7 +1655,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease4-PhenotypicFeature3-negatively_correlated_with:
     - inputs:
@@ -1672,7 +1673,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease4-PhenotypicFeature3-positively_correlated_with:
     - inputs:
@@ -1690,7 +1691,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease4-PhenotypicFeature4-negatively_correlated_with:
     - inputs:
@@ -1708,7 +1709,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease4-PhenotypicFeature4-positively_correlated_with:
     - inputs:
@@ -1726,7 +1727,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease4-Procedure3-negatively_correlated_with:
     - inputs:
@@ -1744,7 +1745,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Disease4-Procedure3-positively_correlated_with:
     - inputs:
@@ -1762,7 +1763,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature1-Disease2-negatively_correlated_with:
     - inputs:
@@ -1780,7 +1781,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature1-Disease2-positively_correlated_with:
     - inputs:
@@ -1798,7 +1799,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature1-Disease3-negatively_correlated_with:
     - inputs:
@@ -1816,7 +1817,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature1-Disease3-positively_correlated_with:
     - inputs:
@@ -1834,7 +1835,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature1-Disease4-negatively_correlated_with:
     - inputs:
@@ -1852,7 +1853,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature1-Disease4-positively_correlated_with:
     - inputs:
@@ -1870,7 +1871,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature1-PhenotypicFeature1-negatively_correlated_with:
     - inputs:
@@ -1888,7 +1889,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature1-PhenotypicFeature1-positively_correlated_with:
     - inputs:
@@ -1906,7 +1907,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature1-PhenotypicFeature3-negatively_correlated_with:
     - inputs:
@@ -1924,7 +1925,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature1-PhenotypicFeature3-positively_correlated_with:
     - inputs:
@@ -1942,7 +1943,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature1-PhenotypicFeature4-negatively_correlated_with:
     - inputs:
@@ -1960,7 +1961,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature1-PhenotypicFeature4-positively_correlated_with:
     - inputs:
@@ -1978,7 +1979,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature1-Procedure3-negatively_correlated_with:
     - inputs:
@@ -1996,7 +1997,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature1-Procedure3-positively_correlated_with:
     - inputs:
@@ -2014,7 +2015,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature3-Disease2-negatively_correlated_with:
     - inputs:
@@ -2032,7 +2033,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature3-Disease2-positively_correlated_with:
     - inputs:
@@ -2050,7 +2051,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature3-Disease3-negatively_correlated_with:
     - inputs:
@@ -2068,7 +2069,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature3-Disease3-positively_correlated_with:
     - inputs:
@@ -2086,7 +2087,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature3-Disease4-negatively_correlated_with:
     - inputs:
@@ -2104,7 +2105,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature3-Disease4-positively_correlated_with:
     - inputs:
@@ -2122,7 +2123,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature3-PhenotypicFeature1-negatively_correlated_with:
     - inputs:
@@ -2140,7 +2141,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature3-PhenotypicFeature1-positively_correlated_with:
     - inputs:
@@ -2158,7 +2159,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature3-PhenotypicFeature3-negatively_correlated_with:
     - inputs:
@@ -2176,7 +2177,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature3-PhenotypicFeature3-positively_correlated_with:
     - inputs:
@@ -2194,7 +2195,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature3-PhenotypicFeature4-negatively_correlated_with:
     - inputs:
@@ -2212,7 +2213,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature3-PhenotypicFeature4-positively_correlated_with:
     - inputs:
@@ -2230,7 +2231,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature3-Procedure3-negatively_correlated_with:
     - inputs:
@@ -2248,7 +2249,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature3-Procedure3-positively_correlated_with:
     - inputs:
@@ -2266,7 +2267,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature4-Disease2-negatively_correlated_with:
     - inputs:
@@ -2284,7 +2285,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature4-Disease2-positively_correlated_with:
     - inputs:
@@ -2302,7 +2303,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature4-Disease3-negatively_correlated_with:
     - inputs:
@@ -2320,7 +2321,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature4-Disease3-positively_correlated_with:
     - inputs:
@@ -2338,7 +2339,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature4-Disease4-negatively_correlated_with:
     - inputs:
@@ -2356,7 +2357,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature4-Disease4-positively_correlated_with:
     - inputs:
@@ -2374,7 +2375,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature4-PhenotypicFeature1-negatively_correlated_with:
     - inputs:
@@ -2392,7 +2393,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature4-PhenotypicFeature1-positively_correlated_with:
     - inputs:
@@ -2410,7 +2411,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature4-PhenotypicFeature3-negatively_correlated_with:
     - inputs:
@@ -2428,7 +2429,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature4-PhenotypicFeature3-positively_correlated_with:
     - inputs:
@@ -2446,7 +2447,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature4-PhenotypicFeature4-negatively_correlated_with:
     - inputs:
@@ -2464,7 +2465,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature4-PhenotypicFeature4-positively_correlated_with:
     - inputs:
@@ -2482,7 +2483,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature4-Procedure3-negatively_correlated_with:
     - inputs:
@@ -2500,7 +2501,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     PhenotypicFeature4-Procedure3-positively_correlated_with:
     - inputs:
@@ -2518,7 +2519,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Procedure3-Disease2-negatively_correlated_with:
     - inputs:
@@ -2536,7 +2537,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Procedure3-Disease2-positively_correlated_with:
     - inputs:
@@ -2554,7 +2555,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease2'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Procedure3-Disease3-negatively_correlated_with:
     - inputs:
@@ -2572,7 +2573,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Procedure3-Disease3-positively_correlated_with:
     - inputs:
@@ -2590,7 +2591,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Procedure3-Disease4-negatively_correlated_with:
     - inputs:
@@ -2608,7 +2609,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Procedure3-Disease4-positively_correlated_with:
     - inputs:
@@ -2626,7 +2627,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Disease4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Procedure3-PhenotypicFeature1-negatively_correlated_with:
     - inputs:
@@ -2644,7 +2645,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Procedure3-PhenotypicFeature1-positively_correlated_with:
     - inputs:
@@ -2662,7 +2663,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature1'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Procedure3-PhenotypicFeature3-negatively_correlated_with:
     - inputs:
@@ -2680,7 +2681,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Procedure3-PhenotypicFeature3-positively_correlated_with:
     - inputs:
@@ -2698,7 +2699,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Procedure3-PhenotypicFeature4-negatively_correlated_with:
     - inputs:
@@ -2716,7 +2717,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Procedure3-PhenotypicFeature4-positively_correlated_with:
     - inputs:
@@ -2734,7 +2735,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/PhenotypicFeature4'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Procedure3-Procedure3-negatively_correlated_with:
     - inputs:
@@ -2752,7 +2753,7 @@ components:
       relation: negatively_associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
     Procedure3-Procedure3-positively_correlated_with:
     - inputs:
@@ -2770,7 +2771,7 @@ components:
       relation: associated_with_risk_for
       response_mapping:
         $ref: '#/components/x-bte-response-mapping/Procedure3'
-      source: EHR Risk Provider (Multiomics)
+      # source: EHR Risk Provider (Multiomics)
       supportBatch: false
   x-bte-response-mapping:
     ChemicalSubstance0:


### PR DESCRIPTION
add x-translator.infores-curie, comment out the hard-coded source

this is because the hard-coded source should instead be the infores curie of the source of the data